### PR TITLE
feat: support `init` command

### DIFF
--- a/.changeset/public-cats-smile.md
+++ b/.changeset/public-cats-smile.md
@@ -1,0 +1,5 @@
+---
+"mangoose-migrate": patch
+---
+
+feat: support `init` command

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,16 +25,16 @@ async function main() {
     .asPromise();
 
   connection.on("error", (err) => {
-    logger.error(`MongoDB connection error: ${err}`);
+    console.error(`MongoDB connection error: ${err}`);
     process.exit(1);
   });
 
   // verify connection
   try {
     await connection.db?.command({ ping: 1 });
-    logger.log("Successfully connected to MongoDB");
+    console.log("Connected to MongoDB");
   } catch (err) {
-    logger.error(`Failed to connect to MongoDB: ${err}`);
+    console.error(`Failed to connect to MongoDB: ${err}`);
     process.exit(1);
   }
 
@@ -44,7 +44,7 @@ async function main() {
       const cmd = new MakeCommand(connection, config);
       await cmd.execute(name);
     } catch (err) {
-      logger.error(`Error creating migration: ${err}`);
+      console.error(`Error creating migration: ${err}`);
       process.exit(1);
     }
   });
@@ -55,19 +55,19 @@ async function main() {
       const cmd = new MigrateCommand(connection, config);
       await cmd.execute();
     } catch (err) {
-      logger.error(`Migration failed: ${err}`);
+      console.error(`Migration failed: ${err}`);
       process.exit(1);
     }
   });
 
   // parse cmd args
   program.parseAsync(process.argv).catch((err) => {
-    logger.error(`Program failed: ${err}`);
+    console.error(`Program failed: ${err}`);
     process.exit(1);
   });
 }
 
 main().catch((err) => {
-  logger.error(err);
+  console.error(err);
   process.exit(1);
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import mongoose from "mongoose";
 import { MigrateCommand } from "./commands/migrate.js";
 import { MakeCommand } from "./commands/make.js";
 import { loadConfig } from "./config.js";
-import { logger } from "./utils.js";
+import { gracefulExit } from "./utils.js";
 
 async function main() {
   const program = new Command();
@@ -35,7 +35,7 @@ async function main() {
     console.log("Connected to MongoDB");
   } catch (err) {
     console.error(`Failed to connect to MongoDB: ${err}`);
-    process.exit(1);
+    await gracefulExit(connection);
   }
 
   // register make command
@@ -43,6 +43,7 @@ async function main() {
     try {
       const cmd = new MakeCommand(connection, config);
       await cmd.execute(name);
+      await gracefulExit(connection);
     } catch (err) {
       console.error(`Error creating migration: ${err}`);
       process.exit(1);
@@ -54,6 +55,7 @@ async function main() {
     try {
       const cmd = new MigrateCommand(connection, config);
       await cmd.execute();
+      await gracefulExit(connection);
     } catch (err) {
       console.error(`Migration failed: ${err}`);
       process.exit(1);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,21 @@
+import fs from "fs/promises";
+import path from "path";
+import { CONFIG_FILES } from "../config.js";
+
+const CONFIG_TEMPLATE = `export default {
+  connectionUri: process.env.MONGODB_URI,
+  migrationsPath: "./migrations",
+  options: {
+    authSource: "admin",
+    retryWrites: true,
+    // ...
+  },
+};`;
+
+export class InitCommand {
+  async execute() {
+    const configPath = path.resolve(process.cwd(), CONFIG_FILES[0]);
+    await fs.writeFile(configPath, CONFIG_TEMPLATE);
+    console.log(`Initialized at ./${CONFIG_FILES[0]}`);
+  }
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,31 @@ const CONFIG_TEMPLATE = `export default {
 export class InitCommand {
   async execute() {
     const configPath = path.resolve(process.cwd(), CONFIG_FILES[0]);
+
+    // check if config file already exists
+    await fs.access(configPath);
+    console.warn(`Config file already exists at ${CONFIG_FILES[0]}`);
+    const override = await promptOverride();
+    if (!override) {
+      throw new Error("Init cancelled");
+    }
+
+    // write config file
     await fs.writeFile(configPath, CONFIG_TEMPLATE);
-    console.log(`Initialized at ./${CONFIG_FILES[0]}`);
+    console.log(`Configuration file created at ./${CONFIG_FILES[0]}`);
+    console.info(
+      "Edit this file with your MongoDB connection details before running migrations."
+    );
   }
+}
+
+async function promptOverride(): Promise<boolean> {
+  console.warn("Override existing config file? (y/N) ");
+  process.stdin.setEncoding("utf8");
+
+  return new Promise((resolve) => {
+    process.stdin.once("data", (data) => {
+      resolve(data.toString().trim().toLowerCase() === "y");
+    });
+  });
 }

--- a/src/commands/make.ts
+++ b/src/commands/make.ts
@@ -57,6 +57,6 @@ export class MakeCommand {
 
     // write file
     await fs.writeFile(filepath, content);
-    logger.log(`Created migration: ${filename}`);
+    console.log(`Created migration: ${filename}`);
   }
 }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -25,7 +25,7 @@ export class MigrateCommand {
           await migration.up(this.connection);
           await recorder.markAsApplied(file);
         } catch (err) {
-          logger.error(`Failed to apply migration ${file}: ${err}`);
+          console.error(`Failed to apply migration ${file}: ${err}`);
           throw err;
         }
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,12 @@
 import path from "path";
 import { MigrationConfig } from "./types.js";
 
+// TODO: support more in future
+export const CONFIG_FILES = [
+  "mangoose.config.js",
+  "mangoose-migrate-config.js",
+];
+
 export async function loadConfig(
   configPath?: string
 ): Promise<MigrationConfig> {
@@ -15,7 +21,7 @@ export async function loadConfig(
   let customConfig: Partial<MigrationConfig> = {};
 
   try {
-    const configFile = configPath || "mangoose-migrate.config.js";
+    const configFile = configPath || CONFIG_FILES[0];
     const fullPath = path.resolve(process.cwd(), configFile);
     const importConfingModule = await import(fullPath);
     customConfig = importConfingModule.default || importConfingModule;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,17 @@
+import { Connection } from "mongoose";
+
+/**
+ * Gracefully closes the MongoDB connection and exits the process.
+ *
+ * @param {mongoose.Connection} connection - The MongoDB connection to close
+ * @returns {Promise<void>} Nothing (exits process)
+ */
+export async function gracefulExit(connection: Connection): Promise<void> {
+  try {
+    await connection.close();
+    process.exit(0);
+  } catch (err) {
+    console.error(`Failed to close connection: ${err}`);
+    process.exit(1);
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,0 @@
-export const logger = {
-  log: (msg: string) => console.log(`🥭: ${msg}`),
-  warn: (msg: string) => console.warn(`🥭: ${msg}`),
-  error: (msg: string) => console.error(`🥭: ${msg}`),
-};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,15 +3,19 @@ import { Connection } from "mongoose";
 /**
  * Gracefully closes the MongoDB connection and exits the process.
  *
- * @param {mongoose.Connection} connection - The MongoDB connection to close
+ * @param {mongoose.Connection} connection The MongoDB connection to close
+ * @param {number} code Process exit code (0 for success, 1 for error)
  * @returns {Promise<void>} Nothing (exits process)
  */
-export async function gracefulExit(connection: Connection): Promise<void> {
+export async function gracefulExit(
+  connection: Connection,
+  code: number
+): Promise<void> {
   try {
     await connection.close();
-    process.exit(0);
+    process.exit(code);
   } catch (err) {
     console.error(`Failed to close connection: ${err}`);
-    process.exit(1);
+    process.exit(code === 0 ? 1 : code);
   }
 }


### PR DESCRIPTION
Add `init` command to initialize a basic config file.
refactored exit function.

Closes #10 #11 